### PR TITLE
Enable drag-and-drop for logic nodes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,12 @@
-import React, { useCallback, useState } from 'react';
-import ReactFlow, { addEdge, MiniMap, Controls } from 'reactflow';
+import React, { useCallback, useRef, useState } from 'react';
+import ReactFlow, {
+  ReactFlowProvider,
+  addEdge,
+  MiniMap,
+  Controls,
+  useNodesState,
+  useEdgesState
+} from 'reactflow';
 import LogicNode from './nodeTypes/LogicNode';
 import { buildEquation } from './utils/generateEquation';
 
@@ -7,39 +14,72 @@ const nodeTypes = { logic: LogicNode };
 const gateTypes = ['AND','OR','NAND','NOR','XOR','NOT'];
 
 function App() {
-  const [elements, setElements] = useState([]);
+  const reactFlowWrapper = useRef(null);
+  const [reactFlowInstance, setReactFlowInstance] = useState(null);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [eqn, setEqn] = useState('');
 
   const onConnect = useCallback(
-    params => setElements(els => addEdge(params, els)),
+    (params) => setEdges((eds) => addEdge(params, eds)),
     []
   );
 
-  const addGate = label => {
-    const id = `${label}_${+new Date()}`;
-    setElements(es => [
-      ...es,
-      {
+  const onDragStart = (event, label) => {
+    event.dataTransfer.setData('application/reactflow', label);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const onDrop = useCallback(
+    (event) => {
+      event.preventDefault();
+      if (!reactFlowInstance) return;
+
+      const label = event.dataTransfer.getData('application/reactflow');
+      if (!label) return;
+
+      const position = reactFlowInstance.project({
+        x: event.clientX - reactFlowWrapper.current.getBoundingClientRect().left,
+        y: event.clientY - reactFlowWrapper.current.getBoundingClientRect().top,
+      });
+      const id = `${label}_${+new Date()}`;
+
+      const newNode = {
         id,
         type: 'logic',
-        position: { x: 250, y: 50 + es.length * 70 },
-        data: { label }
-      }
-    ]);
+        position,
+        data: { label },
+      };
+
+      setNodes((nds) => nds.concat(newNode));
+    },
+    [reactFlowInstance]
+  );
+
+  const onDragOver = (event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
   };
 
   const generate = () => {
-    const nodes = elements.filter(e => e.id && !e.source);
-    const edges = elements.filter(e => e.source);
     setEqn(buildEquation(nodes, edges));
   };
 
   return (
-    <div className="container">
+    <ReactFlowProvider>
+      <div className="container">
       <div className="sidebar">
         <div className="description">Drag gates onto canvas:</div>
-        {gateTypes.map(g => (
-          <button key={g} onClick={() => addGate(g)}>{g}</button>
+        {gateTypes.map((g) => (
+          <div
+            key={g}
+            className="dndnode"
+            onDragStart={(e) => onDragStart(e, g)}
+            draggable
+          >
+            {g}
+          </div>
         ))}
         <div className="description">Then connect and click:</div>
         <button onClick={generate}>Generate Equation</button>
@@ -48,19 +88,24 @@ function App() {
           <div style={{ wordBreak: 'break-all' }}>{eqn}</div>
         </div>
       </div>
-      <div className="reactflow-wrapper">
+      <div className="reactflow-wrapper" ref={reactFlowWrapper} onDrop={onDrop} onDragOver={onDragOver}>
         <ReactFlow
-          elements={elements}
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           nodeTypes={nodeTypes}
           snapToGrid={true}
           snapGrid={[15, 15]}
+          onInit={setReactFlowInstance}
         >
           <MiniMap />
           <Controls />
         </ReactFlow>
       </div>
     </div>
+    </ReactFlowProvider>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -38,3 +38,14 @@ body, html, #root {
   margin-left: 8px;
   padding: 6px 12px;
 }
+
+.dndnode {
+  padding: 6px 12px;
+  background: #444;
+  color: #fff;
+  border: 1px solid #222;
+  border-radius: 4px;
+  cursor: grab;
+  user-select: none;
+  margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- update ReactFlow usage to current API
- add drag-and-drop support for logic nodes
- style draggable node elements

## Testing
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687c0518849c8325841786a1cd5944f9