### PR TITLE
Enhance logic designer with input nodes and save/load

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,8 @@ body, html, #root {
   background: #222;
   color: #fff;
   padding: 10px;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar .description {
@@ -48,4 +50,18 @@ body, html, #root {
   cursor: grab;
   user-select: none;
   margin-bottom: 5px;
+}
+
+.sidebar button {
+  margin-top: 5px;
+  padding: 6px 12px;
+  background: #555;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sidebar button:hover {
+  background: #666;
 }

--- a/src/nodeTypes/InputNode.js
+++ b/src/nodeTypes/InputNode.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Handle } from 'reactflow';
+
+export default function InputNode({ data }) {
+  return (
+    <div style={{
+      padding: 10,
+      border: '2px solid #2c7',
+      borderRadius: 5,
+      background: '#e8f5e9',
+      textAlign: 'center',
+      minWidth: 60,
+    }}>
+      <div style={{ fontSize: 12, marginBottom: 4 }}>Input</div>
+      <div style={{ fontSize: 20, fontWeight: 'bold' }}>{data.label}</div>
+      <Handle type="source" position="bottom" style={{ background: '#2c7' }} />
+    </div>
+  );
+}

--- a/src/utils/generateEquation.js
+++ b/src/utils/generateEquation.js
@@ -5,6 +5,9 @@ export function buildEquation(nodes, edges) {
   // recursive traversal
   function recurse(id) {
     const node = map[id];
+    if (node.type === 'input') {
+      return node.data.label;
+    }
     const inEdges = edges.filter(e => e.target === id);
     if (node.data.label === 'NOT') {
       const input = inEdges[0]?.source;


### PR DESCRIPTION
## Summary
- add new `InputNode` type
- let users save, load, and clear designs via localStorage
- support `INPUT` nodes in equation generation
- improve sidebar styles and add buttons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c08c9f290832588f88760743dd915